### PR TITLE
Add cmsis_svd to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ chipwhisperer
 unicorn
 capstone
 tqdm
+cmsis_svd


### PR DESCRIPTION
Requires cmsis_svd in 2_bootrom_emulation.